### PR TITLE
merge: docs(shaders): user documentation for contrast shader

### DIFF
--- a/userdoc/docs/.vitepress/config.mts
+++ b/userdoc/docs/.vitepress/config.mts
@@ -12,6 +12,14 @@ export default defineConfig({
         nav: [
           { text: 'Home', link: '/' },
         ],
+        sidebar: [
+          {
+            text: 'Shaders',
+            items: [
+              { text: 'Contrast', link: '/shaders/contrast' }
+            ]
+          }
+        ],
         socialLinks: [
           { icon: 'github', link: 'https://github.com/ShimeraTeam/Shimera' }
         ]
@@ -23,6 +31,14 @@ export default defineConfig({
       themeConfig: {
         nav: [
           { text: 'Accueil', link: '/fr' },
+        ],
+        sidebar: [
+          {
+            text: 'Shaders',
+            items: [
+              { text: 'Contraste', link: '/fr/shaders/contrast' }
+            ]
+          }
         ],
         socialLinks: [
           { icon: 'github', link: 'https://github.com/ShimeraTeam/Shimera' }

--- a/userdoc/docs/fr/shaders/contrast.md
+++ b/userdoc/docs/fr/shaders/contrast.md
@@ -1,0 +1,31 @@
+# Shader de Contraste
+
+**Fichier :** `res/shader/postprocessing/contrast.frag`
+
+## Description
+Ajuste le contraste de l'image rendue en ajustant la distance de chaque composante de couleur par rapport au gris moyen (0.5).
+
+## Paramètres
+| Valeur | Effet |
+|--------|--------|
+| `0.0` | Aucun contraste (gris uniforme) |
+| `1.0` | Contraste original (aucun changement) |
+| `> 1.0` | Contraste augmenté |
+
+## Détails Techniques
+- Le shader utilise 0.5 comme point pivot pour l'ajustement du contraste
+- Les résultats sont limités à la plage valide `[0.0, 1.0]` pour éviter le débordement de couleur
+- Le canal alpha est préservé de l'image originale
+
+## Exemple d'Utilisation
+
+```cpp
+// Définir le contraste à 1.5 (50% de contraste en plus)
+glUniform1f(contrastLocation, 1.5f);
+
+// Définir le contraste à 0.5 (50% de contraste en moins)
+glUniform1f(contrastLocation, 0.5f);
+
+// Définir le contraste à 0.0 (aucun contraste - gris)
+glUniform1f(contrastLocation, 0.0f);
+```

--- a/userdoc/docs/shaders/contrast.md
+++ b/userdoc/docs/shaders/contrast.md
@@ -1,0 +1,31 @@
+# Contrast Shader
+
+**File:** `res/shader/postprocessing/contrast.frag`
+
+## Description
+Adjusts the contrast of the rendered image by scaling the distance of each color component from middle gray (0.5).
+
+## Parameters
+| Value | Effect |
+|-------|--------|
+| `0.0` | No contrast (uniform gray) |
+| `1.0` | Original contrast (no change) |
+| `> 1.0` | Increased contrast |
+
+## Technical Details
+- The shader uses 0.5 as the pivot point for contrast adjustment
+- Results are clamped to the valid range `[0.0, 1.0]` to prevent color overflow
+- The alpha channel is preserved from the original image
+
+## Usage Example
+
+```cpp
+// Set contrast to 1.5 (50% more contrast)
+glUniform1f(contrastLocation, 1.5f);
+
+// Set contrast to 0.5 (50% less contrast)
+glUniform1f(contrastLocation, 0.5f);
+
+// Set contrast to 0.0 (no contrast - gray)
+glUniform1f(contrastLocation, 0.0f);
+```


### PR DESCRIPTION
This pull request adds documentation for the contrast shader in both English and French, and updates the VitePress configuration to include these new shader docs in the sidebar navigation for both languages.

Documentation additions:
Added a new English documentation page for the contrast shader at `userdoc/docs/shaders/contrast.md`, describing its purpose, parameters, technical details, and usage examples.
Added a new French documentation page for the contrast shader at `userdoc/docs/fr/shaders/contrast.md`, with equivalent content to the English version.
